### PR TITLE
Added pending payments to dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -29,16 +29,32 @@ class DashboardController < ApplicationController
   def earnings
     posts = Post.where(user_id: current_user.id).all
     @succesful_orders = []
-    @total_earned = 0
+    @on_account = 0
 
     posts.each do |post|
-      tsuccesful_orders = Order.where(post_id: post.id).order("created_at DESC")
+      tsuccesful_orders = Order.where(post_id: post.id).where("created_at <= ?", 2.weeks.ago.utc).order("created_at DESC")
       @succesful_orders += tsuccesful_orders if tsuccesful_orders
     end
 
     @succesful_orders.each do |succesful_order|
-      @total_earned += succesful_order.amount
+      @on_account += succesful_order.amount
     end
+
+
+    @succesful_orders = []
+    @pending = 0
+
+    posts.each do |post|
+      tsuccesful_orders = Order.where(post_id: post.id).where("created_at >= ?", 2.weeks.ago.utc).order("created_at DESC")
+      @succesful_orders += tsuccesful_orders if tsuccesful_orders
+    end
+
+    @succesful_orders.each do |succesful_order|
+      @pending += succesful_order.amount
+    end
+    
+
+    @paid_out = 0
   end
 
   def projects

--- a/app/views/dashboard/earnings.html.erb
+++ b/app/views/dashboard/earnings.html.erb
@@ -3,20 +3,25 @@
 
   <div class="dashboard__content">
     <h3 class="content__title">Earnings</h3>
-    <h1 class="content__subtitle">&euro; <%= @total_earned %> on Account</h1>
+    <h1 class="content__subtitle">&euro; <%= @on_account %> on Account</h1>
     <a href="javascript:void(0)" class="button button--ghost content__button">withdrawal</a>
     <div class="content__subject">
       <div class="content__earning">
         <h3 class="earning__title">Current Balance</h3>
         <div class="earning__box">
           <i class="earning__icon material-icons">assignment_ind</i>
-          <span class="earning__total">&euro; <%= @total_earned %></span>
+          <span class="earning__total">&euro; <%= @on_account %></span>
           <span class="earning__label">On account</span>
         </div>
         <div class="earning__box">
           <i class="earning__icon material-icons">assignment_ind</i>
-          <span class="earning__total">&euro; <%= @total_earned %></span>
+          <span class="earning__total">&euro; <%= @paid_out %></span>
           <span class="earning__label">Paid out</span>
+        </div>
+        <div class="earning__box">
+          <i class="earning__icon material-icons">assignment_ind</i>
+          <span class="earning__total">&euro; <%= @pending %></span>
+          <span class="earning__label">Pending</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Payments can only be withdrawal if the payment is made > 2 weeks ago.  This is to prevent the payment from getting cancelled.

This PR adds the “Pending” number to the dashboard.

![image](https://user-images.githubusercontent.com/12848235/30216118-3c8541b8-94b2-11e7-9a97-841f1c0feaf3.png)
