### PR TITLE
Added post preview

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :authorize, except: [:show, :index, :search, :category]
+  before_action :authorize, except: [:show, :index, :search, :category, :preview]
   before_action only: [:new] do
     if check_user_level(0)
       redirect_to dashboard_path
@@ -31,6 +31,10 @@ class PostsController < ApplicationController
         raise ActionController::RoutingError.new("Not Found")
       end
     end
+  end
+
+  def preview
+    @post = Post.find params[:id]
   end
 
   def category

--- a/app/views/layouts/_preview_header.html.erb
+++ b/app/views/layouts/_preview_header.html.erb
@@ -1,0 +1,15 @@
+<header class="header">
+  <div class="header__column">
+    <%= link_to root_path do %>
+      <%= image_tag("logoCSSmarket.png", class: "header__logo") %>
+    <% end %>
+
+    <!-- tablet and higher -->
+    <%= link_to "Return to post", post_path(@post.id), class: "header__link header__link--tablet" %>
+  </div>
+  <div class="header__column">
+    <%= link_to @post.title, post_path(@post.id), class: "header__link header__link--tablet" %>
+  </div>
+</header>
+
+<%= stylesheet_link_tag "uploads/post_#{@post.id}/application", media: "all", "data-turbolinks-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,10 +40,20 @@
   </head>
 
   <body>
-    <%= render "layouts/header" %>
+    <% id = @post ? @post.id : 0 %>
 
-    <%= yield %>
+    <% if current_page?(post_preview_path(id)) %>
+      <%= render "layouts/preview_header" %>
 
-    <%= render "layouts/footer" %>
+      <div class="preview-post-<%= @post.id %>">
+        <%= yield %>
+      </div>
+    <% else %>
+      <%= render "layouts/header" %>
+
+      <%= yield %>
+      
+      <%= render "layouts/footer" %>
+    <% end %>
   </body>
 </html>

--- a/app/views/posts/preview.html.erb
+++ b/app/views/posts/preview.html.erb
@@ -1,0 +1,1 @@
+<%= render "posts/uploads/post_#{@post.id}" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -40,7 +40,7 @@
   <aside class="post__aside">
     <span class="post__price">&euro; <%= @post.price %></span>
     <p class="post__licence"><%= @post.license %></p>
-    <a href="#" class="post__button button button--grey">Live Preview</a>
+    <%= link_to "Live Preview", post_preview_path(@post.id), class: "post__button button button--grey" %>
 
     <% if @has_ordered %>
       <%= link_to "Download", dashboard_downloads_path, class: "post__button button button--gradient" %>

--- a/app/views/posts/uploads/_post_1.html.erb
+++ b/app/views/posts/uploads/_post_1.html.erb
@@ -1,0 +1,3 @@
+<div class="example-div">
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
   get "/admin/posts", as: "admin_posts"
   get "/admin/widthdrawls", as: "admin_widthdrawls"
 
+  get "/posts/:id/preview" => "posts#preview", as: "post_preview"
+
   resources :posts
   resources :cart_posts
   resources :charges

--- a/vendor/assets/stylesheets/uploads/post_1/_general.scss
+++ b/vendor/assets/stylesheets/uploads/post_1/_general.scss
@@ -1,0 +1,5 @@
+.example-div {
+  width: 200px;
+  height: 200px;
+  background: red;
+}

--- a/vendor/assets/stylesheets/uploads/post_1/application.scss
+++ b/vendor/assets/stylesheets/uploads/post_1/application.scss
@@ -1,0 +1,3 @@
+.preview-post-1 {
+  @import "general";
+}


### PR DESCRIPTION
- Posts html goes in `app/views/posts/uploads/post_[id]`
- Post SCSS goes in `vender/stylesheets/post_[id]`
- SCSS is wrapped in `.preview_post_[id]` to prevent leaking CSS to our own style.

fixed #68 

![2017-11-05 14 21 10](https://user-images.githubusercontent.com/12848235/32415138-040626d0-c235-11e7-8b30-e9d8e4992a66.gif)
