### PR TITLE
Allow a user to delete his account

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,7 +1,7 @@
 class Admin::BaseController < ApplicationController
   before_action :authorize
   before_action do
-    if !check_user_level(100)
+    if !check_user_level("admin")
       redirect_to root_path
     end
   end

--- a/app/controllers/dashboard/downloads_controller.rb
+++ b/app/controllers/dashboard/downloads_controller.rb
@@ -9,8 +9,13 @@ class Dashboard::DownloadsController < Dashboard::BaseController
     end
 
     @posts.each do |post|
-      user = User.select("id", "name").find_by_id(post.user_id)
-      post.user_name = user.name
+      user = User.select("id", "name", "status").find_by_id(post.user_id)
+
+      if user.deleted?
+        post.user_name = "[deleted]"
+      else
+        post.user_name = user.name
+      end
     end
 
     @total_posts = @posts ? @posts.count : 0

--- a/app/controllers/dashboard/earnings_controller.rb
+++ b/app/controllers/dashboard/earnings_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::EarningsController < Dashboard::BaseController
   before_action do
-    if check_user_level(0)
+    if check_user_level("regular")
       redirect_to user_settings_path
     end
   end

--- a/app/controllers/dashboard/projects_controller.rb
+++ b/app/controllers/dashboard/projects_controller.rb
@@ -1,6 +1,6 @@
 class Dashboard::ProjectsController < Dashboard::BaseController
   before_action do
-    if check_user_level(0)
+    if check_user_level("regular")
       redirect_to user_settings_path
     end
   end

--- a/app/controllers/declined_posts_controller.rb
+++ b/app/controllers/declined_posts_controller.rb
@@ -1,7 +1,7 @@
 class DeclinedPostsController < ApplicationController
   before_action :authorize
   before_action do
-    if !check_user_level(100)
+    if !check_user_level("admin")
       redirect_to root_path
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,6 +36,15 @@ class UsersController < ApplicationController
 
   end
 
+  def destroy
+    @user = User.find_by_id current_user.id
+
+    @user.update(name: SecureRandom.urlsafe_base64(4), email: "#{SecureRandom.urlsafe_base64(4)}@deleted.com", password: SecureRandom.urlsafe_base64(16), level: 0, nano_address: "", paypal_address: "", status: 1)
+
+    session[:user_id] = nil
+    redirect_to login_path
+  end
+
   private
 
   def user_params

--- a/app/controllers/withdrawals_controller.rb
+++ b/app/controllers/withdrawals_controller.rb
@@ -1,12 +1,12 @@
 class WithdrawalsController < ApplicationController
   before_action :authorize
   before_action only: [:update] do
-    if !check_user_level(100)
+    if !check_user_level("admin")
       redirect_to root_path
     end
   end
   before_action only: [:create] do
-    if check_user_level(0)
+    if check_user_level("regular")
       redirect_to root_path
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   has_secure_password
 
+  enum level: { regular: 0, seller: 1, admin: 100 }
+  enum status: { active: 0, deleted: 1 }
+
   validates :name, uniqueness: true, length: { minimum: 4 }
   validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
   validates_numericality_of :cut_percentage, greater_than: 0, less_than: 1

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -13,6 +13,7 @@
         <th>Name</th>
         <th>Email</th>
         <th>Created at</th>
+        <th>Status</th>
       </tr>
 
       <% @users.each do |user| %>
@@ -33,6 +34,7 @@
           <td><%= link_to user.name, profile_path(user.name) %></td>
           <td><%= user.email %></td>
           <td><%= user.created_at.strftime("%d %b. %Y, %H:%M") %></td>
+          <td><%= user.status %></td>
         </tr>
       <% end %>
     </div>

--- a/app/views/dashboard/_menu.html.erb
+++ b/app/views/dashboard/_menu.html.erb
@@ -7,7 +7,7 @@
     </span>
   <% end %>
 
-  <% if !check_user_level(0) %>
+  <% unless check_user_level("regular") %>
     <%= link_to dashboard_earnings_path, class: "dashboard__link #{active_class_for("dashboard__link--is-active", dashboard_earnings_path)}" do %>
       <span class="link__name">
         <i class="material-icons">euro_symbol</i>
@@ -17,7 +17,7 @@
     <% end %>
   <% end %>
 
-  <% if !check_user_level(0) %>
+  <% unless check_user_level("regular") %>
     <%= link_to dashboard_projects_path, class: "dashboard__link #{active_class_for("dashboard__link--is-active", dashboard_projects_path)}" do %>
       <span class="link__name">
         <i class="material-icons">developer_board</i>
@@ -35,7 +35,7 @@
     <span class="link__number"></span>
   <% end %>
 
-  <% if !check_user_level(0) %>
+  <% unless check_user_level("regular") %>
     <%= link_to new_post_path, class: "dashboard__link #{active_class_for("dashboard__link--is-active", new_post_path)}" do %>
       <span class="link__name">
         <i class="material-icons">file_upload</i>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
     <!-- tablet and higher -->
     <%= link_to "About", page_path("about"), class: "header__link header__link--tablet" %>
     <% if current_user %>
-      <%= link_to "Sell", check_user_level(0) ? page_path("sell") : new_post_path, class: "header__link header__link--tablet" %>
+      <%= link_to "Sell", check_user_level("regular") ? page_path("sell") : new_post_path, class: "header__link header__link--tablet" %>
     <% else %>
       <%= link_to "Sell", page_path("sell"), class: "header__link header__link--tablet" %>
     <% end %>
@@ -20,7 +20,7 @@
     </a>
     <!-- tablet and higher -->
     <% if current_user %>
-      <%= link_to "admin", admin_users_path, class: "header__link header__link--tablet" if check_user_level(100)  %>
+      <%= link_to "admin", admin_users_path, class: "header__link header__link--tablet" if check_user_level("admin")  %>
       <%= link_to "dashboard", user_settings_path, class: "header__link header__link--tablet" %>
       <%= link_to "logout", logout_path, class: "header__link header__link--tablet" %>
     <% else %>
@@ -36,7 +36,7 @@
     <i class="menu__icon menu__icon--close material-icons">arrow_forward</i>
   </span>
 
-  <% if check_user_level(0) %>
+  <% if check_user_level("regular") %>
     <span class="menu__link menu__link--seller">
       <span class="menu__label">Become a seller</span>
       <a href="#" class="button button--white">Start selling</a>
@@ -53,7 +53,7 @@
     </span>
   <% end %>
 
-  <% if check_user_level(100) %>
+  <% if check_user_level("admin") %>
     <%= link_to admin_users_path, class: "menu__link" do %>
       <i class="menu__icon material-icons">dashboard</i>
       <span class="menu__label">Admin</span>

--- a/app/views/pages/sell.html.erb
+++ b/app/views/pages/sell.html.erb
@@ -42,7 +42,7 @@
             </div>
             <span class="step__title">You haven't completed step 1</span>
           </div>
-        <% elsif !check_user_level(0) %>
+        <% elsif !check_user_level("regular") %>
           <div class="steps__overlay">
             <div class="step__number step__number--completed"><i class="material-icons">check</i></div>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,11 @@
     <h1 class="intro__title intro__title--small"><%= @post.title %></h1>
     <% if @author.name %>
       <span class="intro__subtitle intro__subtitle--small">
-        By <%= link_to @author.name, profile_path(@author.name) %>
+        <% if @author.deleted? %>
+          By <%= link_to "[deleted]", "#" %>
+        <% else %>
+          By <%= link_to @author.name, profile_path(@author.name) %>
+        <% end %>
         in <%= link_to @post.categories, post_category_path(@post.categories) %>
         created at <span><%= @post.created_at.strftime("%B %d, %Y") %></span>
       </span>
@@ -28,10 +32,6 @@
 
         <% if @has_ordered %>
           <%= link_to "Download", dashboard_downloads_path, class: "post__button button button--large button--gradient button--full" %>
-        <% elsif current_user %>
-
-        <% else %>
-          <%= link_to "Add to Cart (€#{@post.price})", login_path, class: "post__button button button--large button--green button--full" %>
         <% end %>
       </div>
       <span class="actions__title">
@@ -48,53 +48,59 @@
   <aside class="post__aside">
     <%= link_to "Live Preview", post_preview_path(@post.nice_url), class: "button button--large button--gradient" %>
 
-    <div class="accordion" data-role="charge-container">
-      <% if current_user && current_user.id == @post.user_id || check_user_level(100) %>
-        <% if @post.status == 0 && @awaiting_edit.present? %>
-          <%= render "posts/accordion", icon: "remove_red_eye", price: "In review", name: @post.title do %>
-            <span>This post is waiting for approval</span>
+    <% unless @author.deleted? %>
+      <div class="accordion" data-role="charge-container">
+        <% if current_user && current_user.id == @post.user_id || check_user_level("admin") %>
+          <% if @post.status == 0 && @awaiting_edit.present? %>
+            <%= render "posts/accordion", icon: "remove_red_eye", price: "In review", name: @post.title do %>
+              <span>This post is waiting for approval</span>
 
-            <% if check_user_level(100) %>
-              <%= form_for @post, url: post_path(@post.id) do |f| %>
-                <%= f.hidden_field :status, value: 1 %>
-                <%= f.submit "Approve Post", class: "post__button button button--gradient" %>
+              <% if check_user_level("admin") %>
+                <%= form_for @post, url: post_path(@post.id) do |f| %>
+                  <%= f.hidden_field :status, value: 1 %>
+                  <%= f.submit "Approve Post", class: "post__button button button--gradient" %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
-        <% end %>
 
-        <% unless @awaiting_edit.present? %>
-          <%= render "posts/accordion", icon: "edit", price: "Edit", name: @post.title do %>
-            <span>Edit your post</span>
-            <%= link_to "Edit now", edit_post_path(@post.nice_url), class: "post__button button button--gradient" %>
-          <% end if current_user && current_user.id == @post.user_id %>
-        <% end %>
-      <% end %>
-      <% if @has_ordered %>
-        <%= render "posts/accordion", icon: "cloud_download", price: "Download", name: @post.title do %>
-          <span>You already bought this project.</span>
-          <%= link_to "Download", dashboard_downloads_path, class: "post__button button button--gradient" %>
-        <% end %>
-      <% else %>
-        <%= render "posts/accordion", icon: "credit_card", price: "€#{@post.price}", name: "Creditcard" do %>
-          <% if current_user %>
-            <%= render "charges/form_creditcard", post: @post %>
-          <% else %>
-            <span>Login or Register to buy<strong><%= @post.title %></strong></span>
-            <%= link_to "Login/Register", login_path, class: "post__button button button--gradient" %>
+          <% unless @awaiting_edit.present? %>
+            <%= render "posts/accordion", icon: "edit", price: "Edit", name: @post.title do %>
+              <span>Edit your post</span>
+              <%= link_to "Edit now", edit_post_path(@post.nice_url), class: "post__button button button--gradient" %>
+            <% end if current_user && current_user.id == @post.user_id %>
           <% end %>
+        <% end %>
+        <% if @has_ordered %>
+          <%= render "posts/accordion", icon: "cloud_download", price: "Download", name: @post.title do %>
+            <span>You already bought this project.</span>
+            <%= link_to "Download", dashboard_downloads_path, class: "post__button button button--gradient" %>
+          <% end %>
+        <% else %>
+          <%= render "posts/accordion", icon: "credit_card", price: "€#{@post.price}", name: "Creditcard" do %>
+            <% if current_user %>
+              <%= render "charges/form_creditcard", post: @post %>
+            <% else %>
+              <span>Login or Register to buy<strong><%= @post.title %></strong></span>
+              <%= link_to "Login/Register", login_path, class: "post__button button button--gradient" %>
+            <% end %>
+          <% end unless current_user && current_user.id == @post.user_id %>
+
+          <%= render "posts/accordion", icon: image_tag("crypto/nano.svg", width: 36), price: "1.042467654", name: "Nano" do %>
+            <% if current_user %>
+              <%= render "charges/form_nano", post: @post %>
+            <% else %>
+              <span>Login or Register to buy<strong><%= @post.title %></strong></span>
+              <%= link_to "Login/Register", login_path, class: "post__button button button--gradient" %>
+            <% end %>
+          <% end if @author.nano_address.present? %>
         <% end unless current_user && current_user.id == @post.user_id %>
+      </div>
+    <% end %>
 
-        <%= render "posts/accordion", icon: image_tag("crypto/nano.svg", width: 36), price: "1.042467654", name: "Nano" do %>
-          <% if current_user %>
-            <%= render "charges/form_nano", post: @post %>
-          <% else %>
-            <span>Login or Register to buy<strong><%= @post.title %></strong></span>
-            <%= link_to "Login/Register", login_path, class: "post__button button button--gradient" %>
-          <% end %>
-        <% end if @author.nano_address.present? %>
-      <% end unless current_user && current_user.id == @post.user_id %>
-    </div>
+    <% if @author.deleted? && @has_ordered %>
+      <%= link_to "Download", dashboard_downloads_path, class: "post__button button button--large button--gradient button--full" %>
+    <% end %>
   </aside>
 </section>
 

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -56,6 +56,6 @@
 
     <h3>Delete your account</h3>
     <p>Once you have deleted your account there is no going back. Your project will still be available to those who have purchased them, but they can no longer be purchased by new users. Any references to your Username or other account details will be removed completely. Any funds that are still on your account will not be transfered.</p>
-    <%= link_to "Delete your account", user_path(current_user), method: :delete, confirm: "Are you sure you want to delete your account? There is no going back!" %>
+    <%= link_to "Delete your account", user_path(current_user), method: :delete, data: { confirm: "Are you sure you want to delete your account? There is no going back!" } %>
   </div>
 </section>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -51,5 +51,11 @@
 
       <%= f.submit "Save", class: "button button--gradient" %>
     <% end %>
+
+    <hr>
+
+    <h3>Delete your account</h3>
+    <p>Once you have deleted your account there is no going back. Your project will still be available to those who have purchased them, but they can no longer be purchased by new users. Any references to your Username or other account details will be removed completely. Any funds that are still on your account will not be transfered.</p>
+    <%= link_to "Delete your account", user_path(current_user), method: :delete, confirm: "Are you sure you want to delete your account? There is no going back!" %>
   </div>
 </section>

--- a/db/migrate/20180518125821_add_status_to_users.rb
+++ b/db/migrate/20180518125821_add_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddStatusToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180415124914) do
+ActiveRecord::Schema.define(version: 20180518125821) do
 
   create_table "declined_posts", force: :cascade do |t|
     t.integer  "post_id"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20180415124914) do
     t.string   "nano_address"
     t.decimal  "cut_percentage",  default: "0.8"
     t.string   "paypal_address"
+    t.integer  "status",          default: 0
   end
 
   create_table "withdrawals", force: :cascade do |t|


### PR DESCRIPTION
- If an account is deleted his posts no longer show up in the overview
or on the homepage
- Posts by the user can still be found with the correct link, but they
cannot be purchased.
- If a user has already purchased a post by a deleted user he can still
download it
- The deleted user shows up as “[deleted]”

Fixed #148

## When a user is deleted he gets given a random username, email address, and password, and the status "deleted"
![image](https://user-images.githubusercontent.com/12848235/40240396-c227c3f0-5ab8-11e8-952d-32d005aed68d.png)

## Posts by deleted users don't show up in the list
![image](https://user-images.githubusercontent.com/12848235/40240423-cff227f0-5ab8-11e8-9b23-ca8ec663fc7c.png)

## If you have purchased a post you can still see it
![image](https://user-images.githubusercontent.com/12848235/40240449-e08883de-5ab8-11e8-8d27-854fb462ae51.png)
![image](https://user-images.githubusercontent.com/12848235/40240463-e5aa0446-5ab8-11e8-8ec9-0bc62057cf39.png)

## Users can delete their account from the settings page
![image](https://user-images.githubusercontent.com/12848235/40240597-25a8fa7a-5ab9-11e8-8643-1dc69fac14ef.png)
![image](https://user-images.githubusercontent.com/12848235/40240700-7a562bec-5ab9-11e8-9b3c-85275132ee65.png)


